### PR TITLE
Gli/caching

### DIFF
--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -22,7 +22,8 @@ class Airship
     private $apiKey;
     private $envKey;
     private $requestOptions = null;
-    private $localCache = array();
+    private $localObjectsCache = array();
+    private $localGateValuesCache = array();
 
     public function __construct($apiKey, $envKey)
     {

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -22,6 +22,7 @@ class Airship
     private $apiKey;
     private $envKey;
     private $requestOptions = null;
+    private $localCache = array();
 
     public function __construct($apiKey, $envKey)
     {

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -56,6 +56,40 @@ class Airship
         return '[Airship object]';
     }
 
+    private function getUniqueId($obj)
+    {
+        $type = '';
+        $id = $obj['id'];
+
+        if (isset($obj['type'])) {
+            $type = $obj['type'];
+        } else {
+            $type = 'User';
+        }
+
+        $groupType = '';
+        $groupId = '';
+
+        if (isset($obj['group'])) {
+            $group = $obj['group'];
+            $groupId = $group['id'];
+
+            if (isset($group['type'])) {
+                $groupType = $group['type'];
+            } else {
+                $groupType = $type . 'Group';
+            }
+        }
+
+        $finalId = $type . '_' . $id;
+
+        if ($groupId !=== '') {
+            $finalId = $finalId . ':' . $groupType . '_' . $groupId;
+        }
+
+        return $finalId;
+    }
+
     private function getGateValuesMap($obj)
     {
         $client = new Client(['base_uri' => self::SERVER_URL]);

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -83,7 +83,7 @@ class Airship
 
         $finalId = $type . '_' . $id;
 
-        if ($groupId !=== '') {
+        if ($groupId !== '') {
             $finalId = $finalId . ':' . $groupType . '_' . $groupId;
         }
 

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -98,7 +98,7 @@ class Airship
         if (isset($this->localObjectsCache[$uniqueId])) {
             $storedObj = $this->localObjectsCache[$uniqueId];
 
-            if ($obj == $storedObj) {
+            if ($obj === $storedObj) {
                 return $this->localGateValuesCache[$uniqueId];
             }
         }

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -91,7 +91,7 @@ class Airship
         return $finalId;
     }
 
-    private function getGateValuesMap($obj)
+    private function getGateValues($obj)
     {
         $client = new Client(['base_uri' => self::SERVER_URL]);
         $response = null;
@@ -116,9 +116,9 @@ class Airship
 
     public function isEnabled($controlName, $obj, $default = false)
     {
-        $objectGateValuesMap = $this->getGateValuesMap($obj);
-        if (isset($objectGateValuesMap[$controlName])) {
-            return $objectGateValuesMap[$controlName]['is_enabled'];
+        $gateValues = $this->getGateValues($obj);
+        if (isset($gateValues[$controlName])) {
+            return $gateValues[$controlName]['is_enabled'];
         } else {
             return $default;
         }
@@ -126,9 +126,9 @@ class Airship
 
     public function getVariation($controlName, $obj, $default = null)
     {
-        $objectGateValuesMap = $this->getGateValuesMap($obj);
-        if (isset($objectGateValuesMap[$controlName])) {
-            return $objectGateValuesMap[$controlName]['variation'];
+        $gateValues = $this->getGateValues($obj);
+        if (isset($gateValues[$controlName])) {
+            return $gateValues[$controlName]['variation'];
         } else {
             return $default;
         }
@@ -136,9 +136,9 @@ class Airship
 
     public function isEligible($controlName, $obj, $default = false)
     {
-        $objectGateValuesMap = $this->getGateValuesMap($obj);
-        if (isset($objectGateValuesMap[$controlName])) {
-            return $objectGateValuesMap[$controlName]['is_eligible'];
+        $gateValues = $this->getGateValues($obj);
+        if (isset($gateValues[$controlName])) {
+            return $gateValues[$controlName]['is_eligible'];
         } else {
             return $default;
         }

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -14,7 +14,7 @@ use GuzzleHttp\Exception\ClientException;
 class Airship
 {
     const PLATFORM = 'php';
-    const VERSION = '1.1.1';
+    const VERSION = '0.1.0';
 
     const SERVER_URL = 'https://api.airshiphq.com';
     const OBJECT_GATE_VALUES_ENDPOINT = '/v1/object-gate-values/';

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -93,6 +93,16 @@ class Airship
 
     private function getGateValues($obj)
     {
+        $uniqueId = $this->getUniqueId($obj);
+
+        if (isset($this->localObjectsCache[$uniqueId])) {
+            $storedObj = $this->localObjectsCache[$uniqueId];
+
+            if ($obj == $storedObj) {
+                return $this->localGateValuesCache[$uniqueId];
+            }
+        }
+
         $client = new Client(['base_uri' => self::SERVER_URL]);
         $response = null;
         try {
@@ -111,7 +121,13 @@ class Airship
         } catch (\Exception $e) {
             throw $e;
         }
-        return json_decode($response->getBody()->getContents(), true);
+
+        $gateValues = json_decode($response->getBody()->getContents(), true);
+
+        $this->localObjectsCache[$uniqueId] = $obj;
+        $this->localGateValuesCache[$uniqueId] = $gateValues;
+
+        return $gateValues;
     }
 
     public function isEnabled($controlName, $obj, $default = false)


### PR DESCRIPTION
1. If the SDK has pulled info regarding a specific object, then cache the result locally to speed up subsequent SDK calls with the same object but different controls.