### PR TITLE
Add Target object to avoid manually building an array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 composer.lock
 /vendor/
+.idea/
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ $obj = [
   "id" => "1234", // "id" must be a string or integer
   "display_name" => "ironman@stark.com" // must be a string. If omitted, the SDK will use the same value as "id" (converted to a string)
 ]
+// or
+$obj = new Target(1234, 'User', 'ironman@stark.com');
 
 // The most compact form can be:
 $obj = [
   "id" => 1234
 ]
+// or
+$obj = new Target(1234);
+
 // as this will translate into:
 $obj = [
   "type" => "User",
@@ -75,6 +80,19 @@ $obj = [
     "age" => 39
   ]
 ]
+// or
+$obj = new Target(
+  1234,
+  'User',
+  'ironman@stark.com',
+  [
+    "t_shirt_size" => "M",
+    "date_created" => "2018-02-18",
+    "time_converted" => "2018-02-20T21:54:00.630815+00:00",
+    "owns_property" => true,
+    "age" => 39
+  ]
+);
 
 // Now in app.airshiphq.com, you can target this particular user using its
 // attributes
@@ -105,6 +123,29 @@ $obj = [
     ]
   ]
 ]
+// or
+$group = new Target(
+  5678,
+  'Club',
+  'SF Homeowners Club',
+  [
+    "founded" => "2016-01-01",
+    "active" => true,
+  ]
+);
+$user = new Target(
+  1234,
+  'User',
+  'ironman@stark.com',
+  [
+    "t_shirt_size" => "M",
+    "date_created" => "2018-02-18",
+    "time_converted" => "2018-02-20T21:54:00.630815+00:00",
+    "owns_property" => true,
+     "age" => 39
+  ],
+  $group
+);
 
 // Inheritance of values `enabled?`, `variation`, and `eligible?` works as follows:
 // 1. If the group is enabled, but the base object is not,

--- a/src/Airship/Airship.php
+++ b/src/Airship/Airship.php
@@ -76,6 +76,10 @@ class Airship
 
     private function getGateValues($obj)
     {
+        if ($obj instanceof Target) {
+            $obj = $obj->toArray();
+        }
+
         $uniqueId = $this->getUniqueId($obj);
 
         if (isset($this->localObjectsCache[$uniqueId])) {

--- a/src/Airship/Target.php
+++ b/src/Airship/Target.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Airship;
+
+class Target
+{
+    const KEY_ID           = 'id';
+    const KEY_TYPE         = 'type';
+    const KEY_DISPLAY_NAME = 'display_name';
+    const KEY_ATTRIBUTES   = 'attributes';
+    const KEY_GROUP        = 'group';
+    const KEY_IS_GROUP     = 'is_group';
+
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $displayName;
+
+    /**
+     * @var array
+     */
+    private $attributes;
+
+    /**
+     * @var \Airship\Target|null
+     */
+    private $group;
+
+    /**
+     * @var bool
+     */
+    private $isGroup;
+
+    /**
+     * @param int                  $id
+     * @param string               $type
+     * @param string|null          $displayName
+     * @param array                $attributes
+     * @param \Airship\Target|null $group
+     * @param bool                 $isGroup
+     */
+    public function __construct(
+        $id,
+        $type = 'User',
+        $displayName = null,
+        $attributes = [],
+        $group = null,
+        $isGroup = false
+    ) {
+        $this->id          = $id;
+        $this->type        = $type;
+        $this->displayName = $displayName !== null ? $displayName : (string) $id;
+        $this->attributes  = $attributes;
+        $this->group       = $group !== null ? $group->setIsGroup(true) : null;
+        $this->isGroup     = $isGroup;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @param string $displayName
+     *
+     * @return $this
+     */
+    public function setDisplayName($displayName)
+    {
+        $this->displayName = $displayName;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param array $attributes
+     *
+     * @return $this
+     */
+    public function setAttributes($attributes)
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * @return \Airship\Target|null
+     */
+    public function getGroup()
+    {
+        return $this->group;
+    }
+
+    /**
+     * @param \Airship\Target $group
+     *
+     * @return $this
+     */
+    public function setGroup($group)
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGroup()
+    {
+        return $this->isGroup;
+    }
+
+    /**
+     * @param bool $isGroup
+     *
+     * @return $this
+     */
+    public function setIsGroup($isGroup)
+    {
+        $this->isGroup = $isGroup;
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        $array = [
+            self::KEY_TYPE         => $this->type,
+            self::KEY_ID           => $this->id,
+            self::KEY_DISPLAY_NAME => $this->displayName,
+        ];
+
+        if (!empty($this->attributes)) {
+            $array[self::KEY_ATTRIBUTES] = $this->attributes;
+        }
+
+        if (!empty($this->group) && $this->group instanceof Target) {
+            $array[self::KEY_GROUP] = $this->group->toArray();
+        }
+
+        if (!empty($this->isGroup)) {
+            $array[self::KEY_IS_GROUP] = $this->isGroup;
+        }
+
+        return $array;
+    }
+}

--- a/tests/Airship/TargetTest.php
+++ b/tests/Airship/TargetTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Airship\Target;
+use Airship\TestCase;
+
+class TargetTest extends TestCase
+{
+    public function testToArray()
+    {
+        $group = new Target(2, 'Group', 'GroupName', ['att2' => 'val2']);
+
+        $target = new Target(1, 'Type', 'TargetName', ['att' => 'val'], $group);
+
+        $this->assertEquals(
+            [
+                Target::KEY_TYPE => 'Type',
+                Target::KEY_ID => 1,
+                Target::KEY_DISPLAY_NAME => 'TargetName',
+                Target::KEY_ATTRIBUTES => [
+                    'att' => 'val',
+                ],
+                Target::KEY_GROUP => [
+                    Target::KEY_TYPE => 'Group',
+                    Target::KEY_ID => 2,
+                    Target::KEY_DISPLAY_NAME => 'GroupName',
+                    Target::KEY_ATTRIBUTES => [
+                        'att2' => 'val2',
+                    ],
+                    Target::KEY_IS_GROUP => true
+                ]
+            ],
+            $target->toArray()
+        );
+    }
+}


### PR DESCRIPTION
This creates a real model of the expected input to the Airship API so it isn't a freeform array that is prone to typos. It doesn't change the SDK's API since the method now accepts both the bare array or the Target object which gets converted into an array.