### PR TITLE
Replace defaults with provided options

### DIFF
--- a/src/Airship/Client/GuzzleClient.php
+++ b/src/Airship/Client/GuzzleClient.php
@@ -33,7 +33,7 @@ class GuzzleClient implements ClientInterface
         $this->apiKey = $apiKey;
         $this->envKey = $envKey;
 
-        $this->client = new Client(array_merge_recursive([
+        $this->client = new Client(array_replace_recursive([
             'base_uri' => self::SERVER_URL,
             'headers' => [
                 'Content-Type'  => 'application/json',


### PR DESCRIPTION
The merge call would have appended any additional options to the defaults array, so you would have multiple values for each config property you provided. The replace call correctly overwrites the defaults with the values provided.